### PR TITLE
Bugfix Basler Cam

### DIFF
--- a/multilog/view/base_classes.py
+++ b/multilog/view/base_classes.py
@@ -86,7 +86,7 @@ class ImageWidget(QSplitter):
         Args:
             data (numpy.array): image
         """
-        self.image_view.setImage(data, scale=1)
+        self.image_view.setImage(data, autoRange=False)
 
     def set_cmap(self, cmap_name="turbo"):
         """Set color map for the image (if data is 2D heatmap)"""


### PR DESCRIPTION
error occurend everytime a picture was taken, due to a wrong parameter. The Parameter was changed so the error wont occure anymore. All functions are maintained