### PR TITLE
Fix of Issue #73

### DIFF
--- a/multilog/view/pyrometer_array_lumasense.py
+++ b/multilog/view/pyrometer_array_lumasense.py
@@ -114,4 +114,4 @@ class PyrometerArrayLumasenseWidget(PlotWidget):
             meas_data (dict): {heat name: measurement time series}
         """
         for sensor in meas_data:
-            self.set_data(sensor, rel_time, meas_data)
+            self.set_data(sensor, rel_time, meas_data[sensor])


### PR DESCRIPTION
**Reason**
This happened because the whole dict at once was handed over, instead of single entrys in a for loop.

**Testing**
Tested on NemoOne with Series-600 Pyrometer.

**Expected Data:**

1. Room Temperature (20-30°C)
2. Temperature changes when transmissivity is changed.


**Recived Data:**

1. Room Temperature (23-24°C)
2. Temperature changes slightly when transmissivity is changed
3. Data is saved
4. No anomalies