### PR TITLE
Added possibility to do auto zeroing once for the DAQ measurements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: doc/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/config_template.yml
+++ b/config_template.yml
@@ -96,7 +96,7 @@ devices:
       nplc: 1  # nplc of all DC measurements, reduce this for higher sampling rates!
       lsync: True  # line sync for all channels
       ocom: True  # offset compensation for all channels
-      azer: False  # automatic zeroing for all channels
+      azer: False  # automatic zeroing for all channels (True: ON, False: OFF, Once: ONCE)
       adel: True  # automatic delay for all channels
       internal-cold-junction: False  # if False: use 0.0°C
     channels:

--- a/multilog/devices/daq6510.py
+++ b/multilog/devices/daq6510.py
@@ -124,6 +124,8 @@ class Daq6510:
             ocom = "OFF"
         if config["settings"]["azer"]:
             azer = "ON"
+        elif config["settings"]["azer"]=="Once":
+            azer = "ONCE"
         else:
             azer = "OFF"
         if config["settings"]["adel"]:
@@ -151,7 +153,10 @@ class Daq6510:
             cmds.append(f"TEMP:AVER OFF, {self.ch_str_tc}\n")
             cmds.append(f"TEMP:LINE:SYNC {lsync}, {self.ch_str_tc}\n")
             cmds.append(f"TEMP:OCOM {ocom}, {self.ch_str_tc}\n")
-            cmds.append(f"TEMP:AZER {azer}, {self.ch_str_tc}\n")
+            if azer=="ONCE":
+                cmds.append(f"AZER:ONCE\n")            
+            else:
+                cmds.append(f"TEMP:AZER {azer}, {self.ch_str_tc}\n")
             cmds.append(f"TEMP:DEL:AUTO {adel}, {self.ch_str_tc}\n")
             for channel in self.ch_list_tc:
                 cmds.append(f'TEMP:NPLC {config["settings"]["nplc"]}, (@{channel})\n')
@@ -161,7 +166,10 @@ class Daq6510:
             cmds.append(f"TEMP:RTD:FOUR PT100, {self.ch_str_pt_100}\n")
             cmds.append(f"TEMP:LINE:SYNC {lsync}, {self.ch_str_pt_100}\n")
             cmds.append(f"TEMP:OCOM {ocom}, {self.ch_str_pt_100}\n")
-            cmds.append(f"TEMP:AZER {azer}, {self.ch_str_pt_100}\n")
+            if azer=="ONCE":
+                cmds.append(f"AZER:ONCE\n")            
+            else:
+                cmds.append(f"TEMP:AZER {azer}, {self.ch_str_pt_100}\n")            
             cmds.append(f"TEMP:DEL:AUTO {adel}, {self.ch_str_pt_100}\n")
             cmds.append(f"TEMP:AVER OFF, {self.ch_str_pt_100}\n")
             for channel in self.ch_list_pt100:
@@ -176,7 +184,10 @@ class Daq6510:
             cmds.append(f"TEMP:RTD:ZERO 1000, {self.ch_str_pt_1000}\n")
             cmds.append(f"TEMP:LINE:SYNC {lsync}, {self.ch_str_pt_1000}\n")
             cmds.append(f"TEMP:OCOM {ocom}, {self.ch_str_pt_1000}\n")
-            cmds.append(f"TEMP:AZER {azer}, {self.ch_str_pt_1000}\n")
+            if azer=="ONCE":
+                cmds.append(f"AZER:ONCE\n")            
+            else:
+                cmds.append(f"TEMP:AZER {azer}, {self.ch_str_pt_1000}\n")
             cmds.append(f"TEMP:DEL:AUTO {adel}, {self.ch_str_pt_1000}\n")
             cmds.append(f"TEMP:AVER OFF, {self.ch_str_pt_1000}\n")
             for channel in self.ch_list_pt1000:
@@ -184,7 +195,11 @@ class Daq6510:
         if self.nb_dcv > 0:
             cmds.append(f'FUNC "VOLT:DC", {self.ch_str_dcv}\n')
             cmds.append(f"VOLT:LINE:SYNC {lsync}, {self.ch_str_dcv}\n")
-            cmds.append(f"VOLT:AZER {azer}, {self.ch_str_dcv}\n")
+            # cmds.append(f"VOLT:AZER OFF, {self.ch_str_dcv}\n")
+            if azer=="ONCE":
+                cmds.append(f"AZER:ONCE\n")            
+            else:
+                cmds.append(f"VOLT:AZER {azer}, {self.ch_str_dcv}\n")
             cmds.append(f"VOLT:DEL:AUTO {adel}, {self.ch_str_dcv}\n")
             cmds.append(f"VOLT:AVER OFF, {self.ch_str_dcv}\n")
             for channel in self.ch_list_dcv:


### PR DESCRIPTION
From DAQ refrence manual:
"When autozero is set to off, the instrument may gradually drift out of specification. To minimize the drift, you can send the once command to make a reference and zero measurement immediately before a test sequence."

Tested with 300ms sampling time and 2 channels
Tested on a Windows Laptop with USB connected directly to DAQ and a Linux PC with Moxa connected to DAQ